### PR TITLE
Make use of the new FastAPI CLI which is simpler

### DIFF
--- a/identity-verification/README.md
+++ b/identity-verification/README.md
@@ -48,10 +48,10 @@ To run the Identity Verification sample locally using Python, follow these steps
 
   Follow the instructions provided above to set up your Falu API key in the .env file.
 
-- Run the `uvicorn`
+- Run the app
 
     ```bash
-    uvicorn main:app --reload
+    fastapi dev
     ```
 
 ### 2. Run Java And Spring Boot

--- a/identity-verification/python/Dockerfile
+++ b/identity-verification/python/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install pipenv
 COPY . .
 RUN pipenv install --system --deploy --ignore-pipfile
 
-CMD ["uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["fastapi", "run"]


### PR DESCRIPTION
The FastAPI CLI still uses `uvicorn` internally.

Docs -> https://fastapi.tiangolo.com/fastapi-cli/